### PR TITLE
8 address fetch test

### DIFF
--- a/tests/integration/town.test.ts
+++ b/tests/integration/town.test.ts
@@ -1,0 +1,125 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { MySqlContainer, StartedMySqlContainer } from "@testcontainers/mysql";
+import mysql, { Connection, Pool } from "mysql2/promise";
+import * as path from "node:path";
+
+import { Town } from "../../backend/src/Town";
+
+/**
+ * Integration tests for the Town class, which fetches random postal codes and town names from the database.
+ *
+ * These tests use Testcontainers to spin up a real MySQL instance, seed it with the provided SQL file,
+ * and verify that Town.getRandomTown() returns valid data that matches the seeded entries.
+ */
+
+let poolQueryFn: Pool["query"];
+let executedSql: string[] = [];
+
+// mock DB module to redirect queries to our test container
+vi.mock("../../backend/src/DB", () => ({
+  pool: {
+    query: (sql: string, values?: unknown[]) => poolQueryFn(sql, values),
+  },
+}));
+
+describe("Town DB integration", () => {
+  let container: StartedMySqlContainer;
+  let connection: Connection;
+
+  const SEED_FILE = path.join(__dirname, "../../backend/db/addresses.sql");
+
+  beforeAll(async () => {
+    container = await new MySqlContainer("mysql:latest")
+      .withDatabase("addresses")
+      .withUsername("test")
+      .withRootPassword("test")
+      .start();
+
+      // copy seed file
+    await container.copyFilesToContainer([
+      {
+        source: SEED_FILE,
+        target: "/seed.sql",
+      },
+    ]);
+
+      // seed database
+    const result = await container.exec([
+      "bash",
+      "-c",
+      `mysql -u${container.getUsername()} -p${container.getUserPassword()} ${container.getDatabase()} < /seed.sql`,
+    ]);
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Seeding failed with exit code ${result.exitCode}: ${result.output}`,
+      );
+    }
+
+      // create connection for test queries
+    connection = await mysql.createConnection({
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      user: container.getUsername(),
+      password: container.getUserPassword(),
+    });
+
+      // redirect pool queries to our connection and track executed SQL
+    poolQueryFn = ((sql: string, values?: unknown[]) => {
+      executedSql.push(sql);
+      return connection.query(sql, values);
+    }) as Pool["query"];
+  });
+
+  beforeEach(() => {
+    executedSql = [];
+    (Town as unknown as { townCount: number }).townCount = 0;
+  });
+
+  afterAll(async () => {
+    await connection?.end();
+    await container?.stop();
+  });
+
+  // --- Tests ---
+
+  it("fetches a town that exists in the postal_code table", async () => {
+    const town = await Town.getRandomTown();
+
+    const [rows] = await connection.query<mysql.RowDataPacket[]>(
+      "SELECT COUNT(*) AS matches FROM postal_code WHERE cPostalCode = ? AND cTownName = ?",
+      [town.postal_code, town.town_name],
+    );
+
+    expect(town).toEqual({
+      postal_code: expect.any(String),
+      town_name: expect.any(String),
+    });
+    expect(rows[0].matches).toBe(1);
+  });
+
+  it("returns correctly shaped data over repeated DB fetches", async () => {
+    for (let i = 0; i < 25; i++) {
+      const town = await Town.getRandomTown();
+
+      expect(town.postal_code).toMatch(/^\d{4}$/);
+      expect(town.town_name.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("Returns a capitalized town name", async () => {
+    const town = await Town.getRandomTown();
+    expect(town.town_name).toMatch(
+      /^[A-ZÆØÅ][a-zæøå]+(?: [A-ZÆØÅ][a-zæøå]+)*$/,
+    );
+  });
+});

--- a/tests/integration/town.test.ts
+++ b/tests/integration/town.test.ts
@@ -43,7 +43,7 @@ describe("Town DB integration", () => {
       .withRootPassword("test")
       .start();
 
-      // copy seed file
+    // copy seed file
     await container.copyFilesToContainer([
       {
         source: SEED_FILE,
@@ -51,11 +51,11 @@ describe("Town DB integration", () => {
       },
     ]);
 
-      // seed database
+    // seed database
     const result = await container.exec([
       "bash",
       "-c",
-      `mysql -u${container.getUsername()} -p${container.getUserPassword()} ${container.getDatabase()} < /seed.sql`,
+      `mysql --default-character-set=utf8mb4 -u${container.getUsername()} -p${container.getUserPassword()} ${container.getDatabase()} < /seed.sql`,
     ]);
 
     if (result.exitCode !== 0) {
@@ -64,16 +64,19 @@ describe("Town DB integration", () => {
       );
     }
 
-      // create connection for test queries
+    // create connection for test queries
     connection = await mysql.createConnection({
       host: container.getHost(),
       port: container.getPort(),
       database: container.getDatabase(),
       user: container.getUsername(),
       password: container.getUserPassword(),
+      charset: "utf8mb4",
     });
 
-      // redirect pool queries to our connection and track executed SQL
+    await connection.query("SET NAMES utf8mb4");
+
+    // redirect pool queries to our connection and track executed SQL
     poolQueryFn = ((sql: string, values?: unknown[]) => {
       executedSql.push(sql);
       return connection.query(sql, values);
@@ -116,10 +119,9 @@ describe("Town DB integration", () => {
     }
   });
 
-  it("Returns a capitalized town name", async () => {
+  it("returns a capitalized town name", async () => {
     const town = await Town.getRandomTown();
-    expect(town.town_name).toMatch(
-      /^[A-ZÆØÅ][a-zæøå]+(?: [A-ZÆØÅ][a-zæøå]+)*$/,
-    );
+    expect(town.town_name.trim()).toBe(town.town_name);
+    expect(town.town_name).toMatch(/^\p{Lu}[\p{L}]*(?: \p{Lu}[\p{L}]*)*$/u);
   });
 });


### PR DESCRIPTION
This pull request adds integration tests for the `Town` class, ensuring that it correctly fetches random postal codes and town names from a real MySQL database. The tests use Testcontainers to spin up a temporary MySQL instance, seed it with test data, and verify the correctness and shape of the data returned by `Town.getRandomTown()`.

Integration test additions:

* Added a new integration test suite in `tests/integration/town.test.ts` that uses Testcontainers to start a MySQL database, seed it with `addresses.sql`, and run tests against the `Town` class.
* Mocked the database pool in the `DB` module to redirect queries to the test container's connection, ensuring isolation from production or development databases.
* Added tests to verify that `Town.getRandomTown()` returns valid, correctly formatted, and capitalized town names that exist in the seeded database.